### PR TITLE
Display feature flags and permissions on account page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/themes": "^3.1.1",
-        "@workos-inc/authkit-react": "0.9.0",
+        "@workos-inc/authkit-react": "^0.11.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.25.1"
@@ -2702,16 +2702,16 @@
       }
     },
     "node_modules/@workos-inc/authkit-js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.9.0.tgz",
-      "integrity": "sha512-zcl2W9LpmoIqDTnFnv6vHfWKJjZUTxZIdw5IfPL5DDTKrvH49qIRudmMIP4dCWYXIKcnMVA5lGU/PuHsimTjDQ=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-js/-/authkit-js-0.13.0.tgz",
+      "integrity": "sha512-iA0Dt7D1BmY2/1s4oeA36W/aRt8/b5iyH6rP4AlgnjrcH2lUGkBgDXL76NXc0M7repkDQTMcJJ2NhCSo2rcWmg=="
     },
     "node_modules/@workos-inc/authkit-react": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-react/-/authkit-react-0.9.0.tgz",
-      "integrity": "sha512-5JJOGwslFw5eL5uEr5vYZghS/BxTWY66d4nAnopk/L46HLqUNIgjfnVBzztGWOZk1pGUFx8s5DSoXFsdGWt0gw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/authkit-react/-/authkit-react-0.11.0.tgz",
+      "integrity": "sha512-67HFSxP4wXC8ECGyvc1yGMwuD5NGkwT2OPt8DavHoKAlO+hRaAlu9wwzqUx1EJrHht0Dcx+l20Byq8Ab0bEhlg==",
       "dependencies": {
-        "@workos-inc/authkit-js": "0.9.0"
+        "@workos-inc/authkit-js": "0.13.0"
       },
       "peerDependencies": {
         "react": ">=17"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/themes": "^3.1.1",
-    "@workos-inc/authkit-react": "0.9.0",
+    "@workos-inc/authkit-react": "0.11.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.25.1"

--- a/src/routes/account.tsx
+++ b/src/routes/account.tsx
@@ -1,10 +1,14 @@
-import { Box, Flex, Heading, Text, TextField } from "@radix-ui/themes";
+import { Box, Button, Flex, Heading, Text, TextField } from "@radix-ui/themes";
 import { useUser } from "../hooks/use-user";
 import { useAuth } from "@workos-inc/authkit-react";
+import { useState } from "react";
 
 export default function Account() {
   const user = useUser();
-  const { role, organizationId } = useAuth();
+  const { role, organizationId, getAccessToken, featureFlags, permissions } =
+    useAuth();
+
+  const [accessToken, setAccessToken] = useState<string | null>(null);
 
   if (!user) {
     return "...";
@@ -17,6 +21,8 @@ export default function Account() {
     role ? ["Role", role] : [],
     ["Id", user.id],
     organizationId ? ["Organization Id", organizationId] : [],
+    featureFlags ? ["Feature Flags", featureFlags.join(", ")] : [],
+    permissions ? ["Permissions", permissions.join(", ")] : [],
   ].filter((arr) => arr.length > 0);
 
   return (
@@ -32,6 +38,23 @@ export default function Account() {
 
       {userFields && (
         <Flex direction="column" justify="center" gap="3" width="400px">
+          <Flex asChild align="center" gap="6" key={"access-token"}>
+            <label>
+              <Text weight="bold" size="3" style={{ width: 100 }}>
+                Access Token
+              </Text>
+
+              <Box flexGrow="1">
+                {accessToken ? (
+                  <TextField.Root value={accessToken || ""} readOnly />
+                ) : (
+                  <Button onClick={() => getAccessToken().then(setAccessToken)}>
+                    Get Access Token
+                  </Button>
+                )}
+              </Box>
+            </label>
+          </Flex>
           {userFields.map(([label, value]) => (
             <Flex asChild align="center" gap="6" key={value}>
               <label>


### PR DESCRIPTION
Display user's enabled feature flags and assigned permissions on Account page. Also add support for looking at the access token (in case user wants to look at it).
![Screenshot 2025-06-18 at 5 26 45 PM](https://github.com/user-attachments/assets/a0f1a6ac-81e3-447f-8c42-bc1d9c5fcbcf)
