### PR TITLE
fix: validate state.returnTo before navigating after auth

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -11,7 +11,7 @@ export const useUser = (): UserOrNull => {
 
   useEffect(() => {
     if (!isLoading && !user) {
-      signIn({ state: { returnTo: location.pathname } });
+      signIn({ state: { returnTo: location.pathname + location.search } });
     }
   }, [isLoading, user]);
 

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -19,7 +19,12 @@ export default function Layout() {
         // protocol-relative URLs (//evil.com), and javascript: URIs. We pass
         // only the path portion to react-router so navigation never leaves the
         // app.
-        const url = new URL(state.returnTo, window.location.origin);
+        let url: URL;
+        try {
+          url = new URL(state.returnTo, window.location.origin);
+        } catch {
+          return;
+        }
         if (url.origin === window.location.origin) {
           navigate(url.pathname + url.search + url.hash);
         }

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -11,8 +11,17 @@ export default function Layout() {
       clientId={import.meta.env.VITE_WORKOS_CLIENT_ID}
       apiHostname={import.meta.env.VITE_WORKOS_API_HOSTNAME}
       onRedirectCallback={({ state }) => {
-        if (state?.returnTo) {
-          navigate(state.returnTo);
+        if (typeof state?.returnTo !== "string") return;
+        // `state` round-trips through the auth redirect as plaintext in the URL
+        // and is not validated by WorkOS, so treat `returnTo` as untrusted
+        // input. Resolve it against our own origin and only navigate if it
+        // stays same-origin — this rejects absolute URLs (https://evil.com),
+        // protocol-relative URLs (//evil.com), and javascript: URIs. We pass
+        // only the path portion to react-router so navigation never leaves the
+        // app.
+        const url = new URL(state.returnTo, window.location.origin);
+        if (url.origin === window.location.origin) {
+          navigate(url.pathname + url.search + url.hash);
         }
       }}
     >


### PR DESCRIPTION
## What

`onRedirectCallback` in `src/routes/root.tsx` now validates `state.returnTo` before navigating:

```tsx
onRedirectCallback={({ state }) => {
  if (typeof state?.returnTo !== "string") return;
  const url = new URL(state.returnTo, window.location.origin);
  if (url.origin === window.location.origin) {
    navigate(url.pathname + url.search + url.hash);
  }
}}
```

Also updates `use-user.ts` to round-trip `location.search` so query params survive the auth redirect.

## Why

`state` round-trips through the OAuth redirect as untrusted URL input. The example app is reference code customers copy, so it should model the safe pattern: resolve `returnTo` against our own origin and only navigate if it stays same-origin. This rejects absolute URLs (`https://evil.com`), protocol-relative URLs (`//evil.com`), and `javascript:` URIs.

React Router's `navigate()` is same-origin-safe via the History API, but the explicit check + comment makes the intent clear and protects copies of this code that swap in `window.location.href`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)